### PR TITLE
Fix execution from PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Running `zctl routingmode` replacing "routingmode" with one of the routing modes
 Debian 10 had a hard time loading the v4l2loopback kernel module, which I solved by disabling UEFI Secure Boot in the BIOS. It's also possible to manually sign the module if you with to keep Secure Boot enabled, but I won't get into that here.
 
 ```
-sudo apt install python3 python3-pip python3-opencv v4l2loopback-utils
+sudo apt install bash coreutils python3 python3-pip python3-opencv v4l2loopback-utils
 sudo depmod -a
 sudo modprobe v4l2loopback
 
@@ -34,7 +34,7 @@ pip3 install numpy pillow
 All dependencies currenly packaged in base ArchLinux repositories.
 
 ```
-sudo pacman -S python3 opencv python-numpy python-pillow hdf5 v4l2loopback-dkms
+sudo pacman -S bash coreutils python3 opencv python-numpy python-pillow hdf5 v4l2loopback-dkms
 sudo depmod -a
 sudo modprobe v4l2loopback
 ```

--- a/zctl
+++ b/zctl
@@ -1,32 +1,36 @@
 #!/bin/bash
 
+_scriptpath="$(dirname "$(readlink -f "$0")")"
+
+cd "${_scriptpath}" || { printf '%s' 'Cannot cd to script directory' >&2 ; exit 1 ;}
+
 case "$1" in
   "start")
-    python3 cameras.py &
+    python3 "${_scriptpath}/cameras.py" &
   ;;
 
   "stop")
-    echo EXIT > status
+    echo EXIT > "${_scriptpath}/status"
   ;;
 
   "gui")
-    python3 gui.py &
+    python3 "${_scriptpath}/gui.py" &
   ;;
 
   "passthrough")
-    echo PASSTHROUGH > status
+    echo PASSTHROUGH > "${_scriptpath}/status"
   ;;
 
   "video")
-    echo VIDEO > status
+    echo VIDEO > "${_scriptpath}/status"
   ;;
 
   "image")
-    echo IMAGE > status
+    echo IMAGE > "${_scriptpath}/status"
   ;;
 
   "status")
-    echo Status: $(cat status)
+    echo Status: "$(cat "${_scriptpath}/status")"
   ;;
 
   *)


### PR DESCRIPTION
If `zctl` is installed in a location other than the desktop, it becomes problematic to run it. `cd`-ing every time - it is not quite usable way. In fact, you shouldn't bind to the current working folder.

This commit allows you to run the script through `PATH` just like regular installed programs. You can symlink to `/usr/share/local/` or `~/.local/bin/` if you like, and everything should work.